### PR TITLE
add place to paste testdata to template

### DIFF
--- a/src/AdventOfCode.jl
+++ b/src/AdventOfCode.jl
@@ -39,6 +39,9 @@ function _template(year, day; include_year = true)
         nothing
     end
     @info part_2(input)
+
+    test = split(\"\"\"
+    \"\"\", \"\\n\") # paste testdata here
     """
 end
 


### PR DESCRIPTION
I always copy in my test data so they get in the same format as the return value of readlines. Would be cool to add the standard place to paste it to the template. Result will be
```
# https://adventofcode.com/2024/day/2

input = readlines("2024/data/day_2.txt")

function part_1(input)
    nothing
end
@info part_1(input)

function part_2(input)
    nothing
end
@info part_2(input)

test = split("""
""", "\n") # paste testdata here
```
You are meant to paste it at the beginning of the line